### PR TITLE
Fix markdown syntax

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -14,8 +14,9 @@ Pull raw content from github
 https://raw.githubusercontent.com/gaberger/ncp_parser/master/configs/frr/router1.cfg
 
 
-FRR commands
+## FRR commands
 
+```
 sudo snap run frr.vtysh -h
 Usage : vtysh [OPTION...]
 
@@ -32,6 +33,7 @@ Integrated shell for FRR.
     --config_dir         Override config directory path
 -w, --writeconfig        Write integrated config (frr.conf) and exit
 -h, --help               Display this help and exit
+```
 
 Note that multiple commands may be executed from the command
 line by passing multiple -c args, or by embedding linefeed
@@ -39,5 +41,4 @@ characters in one or more of the commands.
 
 Report bugs to https://github.com/frrouting/frr/issues
 
-
-sudo snap run frr.vtysh -c "show run"
+```sudo snap run frr.vtysh -c "show run"```


### PR DESCRIPTION
It wasn't clear where to put the closing backquotes on the usage message, and I didn't find the corresponding source for `frr.vtysh` in the repo, so I couldn't verify that way.